### PR TITLE
Change updateNodeStore to check normalView for rendered before triggering...

### DIFF
--- a/LockableBufferedTree.js
+++ b/LockableBufferedTree.js
@@ -182,7 +182,7 @@ Ext.grid.Lockable.override({
 
                 guaranteeRange(rangeStart, rangeEnd);
 
-                if (this.getView().rendered) {
+                if (normalView.rendered) {
                     me.onNormalViewScroll();
                 }
             };


### PR DESCRIPTION
...onNormalViewScroll(). Right now, it checks this.getView().rendered, which seems to throw the error "Object has no method getView()" because at that point, "this" is scoped to the FixedTreeStore. Using "me.getView().rendered" doesn't throw an error but also doesn't appear to ever return true. Using "normalView.rendered" seems to work correctly.
